### PR TITLE
[#7] 메인 팀구하기 리스트 UI 구현

### DIFF
--- a/frontend/src/app/api/listItem.ts
+++ b/frontend/src/app/api/listItem.ts
@@ -16,3 +16,44 @@ export const getItem = async () => {
     throw error;
   }
 };
+
+export const getTeamItem = async () => {
+  const currentDate = new Date().toString();
+  const mockData: {
+    title: string;
+    author: string;
+    tag: string;
+    date: string;
+  }[] = [
+    {
+      title: "PortCloud, IT 커리어 성장 플랫폼 프로젝트 1",
+      author: "남우빈",
+      tag: "프론트엔드",
+      date: currentDate,
+    },
+    {
+      title: "PortCloud, IT 커리어 성장 플랫폼 프로젝트 2",
+      author: "남우빈",
+      tag: "프론트엔드",
+      date: currentDate,
+    },
+    {
+      title: "PortCloud, IT 커리어 성장 플랫폼 프로젝트 3",
+      author: "남우빈",
+      tag: "프론트엔드",
+      date: currentDate,
+    },
+    {
+      title: "PortCloud, IT 커리어 성장 플랫폼 프로젝트 4",
+      author: "남우빈",
+      tag: "프론트엔드",
+      date: currentDate,
+    },
+  ];
+  try {
+    return mockData;
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+};

--- a/frontend/src/app/customComponents/MainTeamList.tsx
+++ b/frontend/src/app/customComponents/MainTeamList.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { getTeamItem } from "../api/listItem";
+
+interface TeamItem {
+  title: string;
+  author: string;
+  tag: string;
+  date: string;
+}
+
+interface MainTeamListProps {
+  title: string;
+}
+
+const MainTeamList = ({ title }: MainTeamListProps) => {
+  const [item, setItem] = useState<TeamItem[]>([]);
+
+  useEffect(() => {
+    const fetchItem = async () => {
+      try {
+        const fetchData = await getTeamItem();
+        setItem(fetchData);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchItem();
+  }, [setItem]);
+
+  return (
+    <div className="flex flex-col gap-[24px]">
+      <p className="font-bold text-[20px]">{title}</p>
+      <ul className="flex gap-[24px]">
+        {item.length > 0 ? (
+          item.map((teamItem, index) => {
+            return (
+              <li
+                key={`${teamItem}-${index}`}
+                className="w-[330px] bg-white border-[2px] border-gray-300 rounded-[20px] p-[24px] cursor-pointer"
+              >
+                <div className="flex gap-[4px] items-center">
+                  <p className="text-gray-500 text-[14px] font-medium">
+                    마감일
+                  </p>
+                  <div className="border-l h-[14px] border-gray-300 "></div>
+                  <p className="text-gray-500 text-[14px] font-medium">
+                    {new Date(teamItem.date).toLocaleDateString()}
+                  </p>
+                </div>
+                <h2 className="text-[18px] font-bold my-[4px]">
+                  {teamItem.title}
+                </h2>
+                <p className="w-fit rounded-[20px] bg-purple-50 px-[16px] py-[6px] box-border text-center font-semibold text-purple-500 text-[14px] my-[12px] mb-[76px]">
+                  {teamItem.tag}
+                </p>
+                <hr />
+                <p className="mt-[18px] text-[14px] font-bold">
+                  {teamItem.author}
+                </p>
+              </li>
+            );
+          })
+        ) : (
+          <p className="w-[1392px] h-[248px] bg-gray-300 rounded-[20px] items-center flex justify-center text-white text-[20px] font-bold">
+            목록이 없습니다
+          </p>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default MainTeamList;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,6 +14,7 @@ import Image from "next/image";
 import mainBannerImg from "@/app/imgs/mainbanner-img.png";
 import { useState, useEffect } from "react";
 import MainList from "./customComponents/MainList";
+import MainTeamList from "./customComponents/MainTeamList";
 
 export default function Home() {
   // 캐러셀 api state
@@ -93,6 +94,7 @@ export default function Home() {
       <section className="w-[1392px] flex my-[48px] flex-col gap-[48px] ">
         <MainList title="인기 프로젝트" />
         <MainList title="인기 포트폴리오" />
+        <MainTeamList title="팀 구하기" />
       </section>
     </main>
   );


### PR DESCRIPTION
## 🔗 관련 이슈
#7 

## 📝 개요

- 메인페이지 내부 팀구하기 리스트 UI 구현

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?
### 현재는 MockData 로 구성하였음 추후에 API 연동 필요
<img width="1580" height="441" alt="캡처3" src="https://github.com/user-attachments/assets/9ee39e4d-e830-4414-b27e-21a05f231447" />


- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
